### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/DeviousWings/CosmosSite/security/code-scanning/1](https://github.com/DeviousWings/CosmosSite/security/code-scanning/1)

In general, the fix is to define an explicit `permissions` block either at the workflow root (so it applies to all jobs) or inside each job, granting only the minimal scopes needed. For this CI workflow, the steps only require read access to the repository contents to check out and build the code. They do not modify issues, pull requests, or releases, so `contents: read` is sufficient as a baseline.

The best fix without changing existing behavior is to add a root-level `permissions` block right after the `name: CI` line. This will apply to all jobs (currently only `build`) that do not define their own permissions. Concretely, in `.github/workflows/ci.yml`, after line 1 (`name: CI`), insert:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed; this is purely a YAML configuration change to the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
